### PR TITLE
[Fix] : 지도 내가 저장한 핀 카드 밖으로 나가는 이슈 해결

### DIFF
--- a/bank/sakura_bank_ver_vue/src/map/components/MapSavedPlacesCard.vue
+++ b/bank/sakura_bank_ver_vue/src/map/components/MapSavedPlacesCard.vue
@@ -66,18 +66,29 @@ const emit = defineEmits([
       >
         <div class="flex items-start justify-between gap-3">
           <!-- 카드 본문 클릭은 해당 저장 장소를 지도 중심으로 가져오는 액션이다. -->
-          <button type="button" class="min-w-0 text-left" @click="emit('focus-place', place)">
+          <button
+            type="button"
+            class="min-w-0 flex-1 overflow-hidden text-left"
+            @click="emit('focus-place', place)"
+          >
             <div class="flex items-center gap-2">
               <MapPin class="h-4 w-4 shrink-0 text-primary" />
-              <p class="truncate font-semibold text-foreground">{{ place.placeName }}</p>
+              <p class="truncate font-semibold text-foreground">
+                {{ place.placeName }}
+              </p>
             </div>
             <p class="mt-1 text-xs font-medium text-primary/80">{{ place.category || '기타' }}</p>
-            <p class="mt-1 text-sm text-muted-foreground">
+            <p class="mt-1 break-words text-sm leading-5 text-muted-foreground">
               {{ place.roadAddressName || place.addressName || '주소 정보 없음' }}
             </p>
-            <p v-if="place.memo" class="mt-2 text-sm text-foreground/80">{{ place.memo }}</p>
+            <p
+              v-if="place.memo"
+              class="mt-2 break-words text-sm leading-5 text-foreground/80"
+            >
+              {{ place.memo }}
+            </p>
           </button>
-          <div class="flex items-center gap-2">
+          <div class="flex shrink-0 items-center gap-2">
             <!-- 수정, 외부 링크, 삭제를 각각 분리된 액션 버튼으로 둔다. -->
             <button
               type="button"


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- fix/#59

📄  **작업한 내용**
소비 지도 페이지 카드 컴포넌트 내에서 카드 밖으로 나가는 문제 

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 💻 관련 이슈
- Resolved: #59 

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 저장된 장소 카드 레이아웃 개선: 클릭 가능 영역이 유연하게 확장되고 텍스트 오버플로우 방지
* 텍스트 렌더링 강화: 장소명, 주소, 메모의 줄바꿈 및 간격 처리 개선
* 액션 버튼 영역 최적화: 편집, 링크, 삭제 버튼의 일관된 너비 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->