### PR TITLE
extra: 헤더 통일, 캘린더일별 지출내역에서 거래내역 수정/제거, 절약레벨 삭제

### DIFF
--- a/bank/sakura_bank_ver_vue/src/amulet/features/pages/AmuletCustom.vue
+++ b/bank/sakura_bank_ver_vue/src/amulet/features/pages/AmuletCustom.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { reactive, ref, onMounted } from 'vue';
 import { Download, RotateCcw, Trash2, Heart, Sparkles } from 'lucide-vue-next';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import UiCard from '@/shared/ui/UiCard.vue';
 import { cn } from '@/shared/lib/utils';
 import { useLoadingStore } from '@/stores/loading';
@@ -203,10 +204,10 @@ const getAdjustedFrame = (frameId, themeId) => {
 
 <template>
   <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold text-foreground flex items-center gap-2">부적 꾸미기 🔮</h1>
-      <p class="text-muted-foreground">행운의 심볼과 문구를 조합해 나만의 부적을 만드세요.</p>
-    </div>
+    <PageIntroHeader
+      title="부적 꾸미기 🔮"
+      description="행운의 심볼과 문구를 조합해 나만의 부적을 완성해보세요."
+    />
 
     <UiCard class="border-none bg-card/80 shadow-sm backdrop-blur-sm overflow-hidden">
       <div

--- a/bank/sakura_bank_ver_vue/src/components/AppSidebar.vue
+++ b/bank/sakura_bank_ver_vue/src/components/AppSidebar.vue
@@ -73,11 +73,7 @@ function onLogout() {
 }
 
 onMounted(async () => {
-  await Promise.all([
-    budget.fetchAll(),
-    categories.fetchAll(),
-    profile.fetchAll(),
-  ]);
+  await Promise.all([budget.fetchAll(), categories.fetchAll(), profile.fetchAll()]);
 });
 </script>
 
@@ -86,13 +82,11 @@ onMounted(async () => {
     :class="
       cn(
         'sticky top-0 z-20 flex h-screen shrink-0 flex-col border-r border-sidebar-border bg-sidebar',
-        collapsed ? 'w-16' : 'w-64',
+        collapsed ? 'w-16' : 'w-64'
       )
     "
   >
-    <div
-      class="flex h-16 items-center gap-2 border-b border-sidebar-border px-4"
-    >
+    <div class="flex h-16 items-center gap-2 border-b border-sidebar-border px-4">
       <div
         class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-lg"
       >
@@ -105,16 +99,13 @@ onMounted(async () => {
 
     <div v-if="!collapsed" class="border-b border-sidebar-border p-4">
       <div class="flex items-center gap-3">
-        <div
-          class="flex h-10 w-10 items-center justify-center rounded-full bg-primary/20 text-lg"
-        >
+        <div class="flex h-10 w-10 items-center justify-center rounded-full bg-primary/20 text-lg">
           🧑‍💻
         </div>
         <div>
           <p class="text-sm font-medium text-sidebar-foreground">
             {{ displayName }}
           </p>
-          <p class="text-xs text-muted-foreground">절약 레벨 Lv.3</p>
         </div>
       </div>
     </div>
@@ -129,15 +120,13 @@ onMounted(async () => {
             'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
             isMainActive(item.to)
               ? 'bg-sidebar-accent text-sidebar-primary'
-              : 'text-sidebar-foreground hover:bg-sidebar-accent/50',
+              : 'text-sidebar-foreground hover:bg-sidebar-accent/50'
           )
         "
       >
         <component
           :is="item.icon"
-          :class="
-            cn('h-5 w-5 shrink-0', isMainActive(item.to) && 'text-primary')
-          "
+          :class="cn('h-5 w-5 shrink-0', isMainActive(item.to) && 'text-primary')"
         />
         <span v-if="!collapsed">{{ item.label }}</span>
       </RouterLink>
@@ -150,7 +139,7 @@ onMounted(async () => {
             'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
             isExtraActive(item)
               ? 'bg-sidebar-accent text-sidebar-primary'
-              : 'text-sidebar-foreground hover:bg-sidebar-accent/50',
+              : 'text-sidebar-foreground hover:bg-sidebar-accent/50'
           )
         "
       >
@@ -163,7 +152,7 @@ onMounted(async () => {
         :class="
           cn(
             'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
-            'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-primary',
+            'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-primary'
           )
         "
         @click="openLogoutModal"
@@ -182,10 +171,6 @@ onMounted(async () => {
       <ChevronLeft v-else class="h-3 w-3" />
     </button>
 
-    <SidebarLogoutModal
-      :open="showLogoutModal"
-      @close="closeLogoutModal"
-      @confirm="onLogout"
-    />
+    <SidebarLogoutModal :open="showLogoutModal" @close="closeLogoutModal" @confirm="onLogout" />
   </aside>
 </template>

--- a/bank/sakura_bank_ver_vue/src/components/PageIntroHeader.vue
+++ b/bank/sakura_bank_ver_vue/src/components/PageIntroHeader.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+});
+
+const todayLabel = computed(() =>
+  new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long',
+  }).format(new Date())
+);
+</script>
+
+<template>
+  <div
+    class="rounded-2xl border border-white/60 bg-gradient-to-r from-rose-50/90 via-pink-50/75 to-amber-50/90 p-5 shadow-sm backdrop-blur-sm"
+  >
+    <p class="text-xs font-semibold tracking-wide text-primary/80">
+      환영합니다, 오늘도 좋은 하루예요 🌸
+    </p>
+    <p class="mt-1 text-xs text-muted-foreground">{{ todayLabel }}</p>
+    <h1 class="mt-3 text-2xl font-bold tracking-tight text-foreground">{{ title }}</h1>
+    <p v-if="description" class="mt-1 text-sm text-muted-foreground">{{ description }}</p>
+  </div>
+</template>

--- a/bank/sakura_bank_ver_vue/src/features/dashboard/views/DashboardView.vue
+++ b/bank/sakura_bank_ver_vue/src/features/dashboard/views/DashboardView.vue
@@ -13,6 +13,7 @@ import {
 } from 'lucide-vue-next';
 
 import UiCard from '@/shared/ui/UiCard.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import StatCard from '../components/StatCard.vue';
 import CategoryPie from '../components/CategoryPie.vue';
 import NewsletterWidget from '../components/NewsletterWidget.vue';
@@ -41,52 +42,40 @@ const previousMonthDate = new Date(currentYear, today.getMonth() - 1, 1);
 const previousYear = previousMonthDate.getFullYear();
 const previousMonth = previousMonthDate.getMonth() + 1;
 
-const dateLabel = computed(() =>
-  new Intl.DateTimeFormat('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    weekday: 'long',
-  }).format(today),
-);
-
-const formatAmount = (val) =>
-  new Intl.NumberFormat('ko-KR').format(Number(val || 0)) + '원';
+const formatAmount = (val) => new Intl.NumberFormat('ko-KR').format(Number(val || 0)) + '원';
 
 // 내역 필터링
 const currentMonthRows = computed(() =>
   budget.items.filter((row) => {
     const d = new Date(row.date);
     return d.getFullYear() === currentYear && d.getMonth() + 1 === currentMonth;
-  }),
+  })
 );
 
 const previousMonthRows = computed(() =>
   budget.items.filter((row) => {
     const d = new Date(row.date);
-    return (
-      d.getFullYear() === previousYear && d.getMonth() + 1 === previousMonth
-    );
-  }),
+    return d.getFullYear() === previousYear && d.getMonth() + 1 === previousMonth;
+  })
 );
 
 // 합계 계산
 const currentIncomeTotal = computed(() =>
   currentMonthRows.value
     .filter((r) => r.type === 'income')
-    .reduce((s, r) => s + Number(r.amount || 0), 0),
+    .reduce((s, r) => s + Number(r.amount || 0), 0)
 );
 
 const currentExpenseTotal = computed(() =>
   currentMonthRows.value
     .filter((r) => r.type === 'expense')
-    .reduce((s, r) => s + Number(r.amount || 0), 0),
+    .reduce((s, r) => s + Number(r.amount || 0), 0)
 );
 
 const previousExpenseTotal = computed(() =>
   previousMonthRows.value
     .filter((r) => r.type === 'expense')
-    .reduce((s, r) => s + Number(r.amount || 0), 0),
+    .reduce((s, r) => s + Number(r.amount || 0), 0)
 );
 
 const percentChange = computed(() => {
@@ -102,15 +91,12 @@ const budgetUsageRate = computed(() => {
 });
 
 const remainingBalance = computed(() =>
-  Math.max(currentIncomeTotal.value - currentExpenseTotal.value, 0),
+  Math.max(currentIncomeTotal.value - currentExpenseTotal.value, 0)
 );
 
 // 차트 데이터
 const categoryMap = computed(() =>
-  [...categories.income, ...categories.expense].reduce(
-    (acc, c) => ({ ...acc, [c.id]: c }),
-    {},
-  ),
+  [...categories.income, ...categories.expense].reduce((acc, c) => ({ ...acc, [c.id]: c }), {})
 );
 
 const pieData = computed(() => {
@@ -187,8 +173,7 @@ const frames = [
   },
   {
     id: 'neon',
-    class:
-      'border-[3px] border-pink-400 shadow-[0_0_15px_rgba(244,114,182,0.6)]',
+    class: 'border-[3px] border-pink-400 shadow-[0_0_15px_rgba(244,114,182,0.6)]',
   },
   {
     id: 'ornate',
@@ -204,8 +189,7 @@ const frames = [
   },
   {
     id: 'sparkle',
-    class:
-      'border-[5px] border-dotted border-amber-500 shadow-[0_0_12px_rgba(245,158,11,0.5)]',
+    class: 'border-[5px] border-dotted border-amber-500 shadow-[0_0_12px_rgba(245,158,11,0.5)]',
   },
 ];
 
@@ -216,9 +200,7 @@ const getAdjustedFrame = (frameId, themeId) => {
   let style = frame.style || '';
   const isDark = ['midnight', 'forest', 'ocean', 'berry'].includes(themeId);
   if (isDark) {
-    className = className
-      .replace(/black/g, 'white')
-      .replace(/opacity-0.2/g, 'opacity-0.5');
+    className = className.replace(/black/g, 'white').replace(/opacity-0.2/g, 'opacity-0.5');
     style = style.replace(/%23000/g, '%23FFF');
   }
   return { className, style };
@@ -236,14 +218,10 @@ onMounted(async () => {
 
 <template>
   <div class="space-y-6 max-w-full mx-auto pb-10">
-    <div class="flex flex-wrap items-start justify-between gap-4">
-      <div>
-        <h1 class="text-2xl font-bold text-foreground tracking-tight">
-          환영합니다, 오늘도 좋은 하루예요 🌸
-        </h1>
-        <p class="text-muted-foreground text-sm">{{ dateLabel }}</p>
-      </div>
-    </div>
+    <PageIntroHeader
+      title="내 지갑 대시보드 🌸"
+      description="이번 달 수입·지출·소비율과 핵심 위젯을 한눈에 확인해보세요."
+    />
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch mb-6">
       <StatCard
@@ -257,9 +235,7 @@ onMounted(async () => {
           <div class="flex items-center gap-1 text-[11px] font-medium">
             <template v-if="Number(percentChange) < 0">
               <ArrowDownRight class="h-3.5 w-3.5 text-green-600" />
-              <span class="text-green-600"
-                >{{ Math.abs(percentChange) }}% 감소</span
-              >
+              <span class="text-green-600">{{ Math.abs(percentChange) }}% 감소</span>
             </template>
             <template v-else>
               <ArrowUpRight class="h-3.5 w-3.5 text-pink-600" />
@@ -294,13 +270,10 @@ onMounted(async () => {
       >
         <template #extra>
           <div class="text-right leading-none self-end pb-0.5">
-            <span class="text-[9px] text-muted-foreground block mb-0.5"
-              >남은 여유 자금</span
-            >
-            <span
-              class="text-[13px] font-bold text-amber-600 whitespace-nowrap"
-              >{{ formatAmount(remainingBalance) }}</span
-            >
+            <span class="text-[9px] text-muted-foreground block mb-0.5">남은 여유 자금</span>
+            <span class="text-[13px] font-bold text-amber-600 whitespace-nowrap">{{
+              formatAmount(remainingBalance)
+            }}</span>
           </div>
         </template>
         <template #footer>
@@ -328,9 +301,7 @@ onMounted(async () => {
               <div class="inline-flex p-3 bg-violet-100 rounded-2xl shrink-0">
                 <PieChartIcon class="h-6 w-6 text-violet-600" />
               </div>
-              <h2 class="text-lg font-bold text-foreground tracking-tight">
-                카테고리별 지출 현황
-              </h2>
+              <h2 class="text-lg font-bold text-foreground tracking-tight">카테고리별 지출 현황</h2>
             </div>
             <div
               class="text-xs text-muted-foreground flex items-center gap-1 opacity-80 hover:opacity-100 transition-opacity"
@@ -363,9 +334,7 @@ onMounted(async () => {
               >
                 <Sparkles class="h-6 w-6 text-amber-600" />
               </div>
-              <h2 class="text-lg font-bold text-foreground tracking-tight">
-                부적 꾸미기
-              </h2>
+              <h2 class="text-lg font-bold text-foreground tracking-tight">부적 꾸미기</h2>
             </div>
             <div
               class="text-xs text-muted-foreground flex items-center gap-1 opacity-80 group-hover:opacity-100 group-hover:text-primary transition-all"
@@ -374,15 +343,13 @@ onMounted(async () => {
             </div>
           </div>
 
-          <div
-            class="px-6 pb-4 flex-1 flex items-center justify-center relative z-10"
-          >
+          <div class="px-6 pb-4 flex-1 flex items-center justify-center relative z-10">
             <div
               v-if="latestCharm"
               :class="
                 cn(
                   'w-40 h-60 rounded-3xl shadow-2xl flex flex-col items-center justify-center p-6 text-center border-4 border-white relative transition-all duration-500 group-hover:scale-105 group-hover:rotate-1 z-20',
-                  getThemeClass(latestCharm.colorTheme),
+                  getThemeClass(latestCharm.colorTheme)
                 )
               "
             >
@@ -390,18 +357,10 @@ onMounted(async () => {
                 :class="
                   cn(
                     'absolute inset-3 rounded-[24px] pointer-events-none',
-                    getAdjustedFrame(
-                      latestCharm.frameStyle,
-                      latestCharm.colorTheme,
-                    ).className,
+                    getAdjustedFrame(latestCharm.frameStyle, latestCharm.colorTheme).className
                   )
                 "
-                :style="
-                  getAdjustedFrame(
-                    latestCharm.frameStyle,
-                    latestCharm.colorTheme,
-                  ).style
-                "
+                :style="getAdjustedFrame(latestCharm.frameStyle, latestCharm.colorTheme).style"
               ></div>
 
               <span
@@ -420,12 +379,8 @@ onMounted(async () => {
               v-else
               class="text-center flex flex-col items-center relative group-hover:scale-105 transition-transform duration-500 z-20"
             >
-              <div
-                class="absolute inset-0 flex items-center justify-center pointer-events-none"
-              >
-                <div
-                  class="w-48 h-64 bg-amber-100/30 rounded-full blur-2xl animate-pulse"
-                ></div>
+              <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <div class="w-48 h-64 bg-amber-100/30 rounded-full blur-2xl animate-pulse"></div>
               </div>
               <div
                 class="w-40 h-60 rounded-3xl border-4 border-dashed border-amber-300 bg-amber-50/70 shadow-2xl flex flex-col items-center justify-center p-6 text-center relative overflow-hidden"
@@ -442,8 +397,7 @@ onMounted(async () => {
                   <Sparkles
                     class="absolute -inset-6 h-20 w-20 text-amber-300 opacity-40 group-hover:opacity-100 group-hover:scale-125 transition-all duration-1000"
                   />
-                  <span
-                    class="text-6xl relative z-20 drop-shadow-xl group-hover:animate-pulse"
+                  <span class="text-6xl relative z-20 drop-shadow-xl group-hover:animate-pulse"
                     >🔮</span
                   >
                 </div>
@@ -451,9 +405,7 @@ onMounted(async () => {
                   class="relative z-10 text-amber-950 font-black italic tracking-tighter leading-tight"
                 >
                   <p class="text-[11px]">행운의 주문을</p>
-                  <p class="text-[9px] text-amber-900/60 font-bold">
-                    비워두었어요
-                  </p>
+                  <p class="text-[9px] text-amber-900/60 font-bold">비워두었어요</p>
                 </div>
               </div>
             </div>

--- a/bank/sakura_bank_ver_vue/src/features/transactions/views/TransactionFormView.vue
+++ b/bank/sakura_bank_ver_vue/src/features/transactions/views/TransactionFormView.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import UiCard from '@/shared/ui/UiCard.vue';
 import UiButton from '@/shared/ui/UiButton.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { useBudgetStore } from '@/features/transactions/stores/budget';
 import { useCategoryStore } from '@/features/transactions/stores/categories';
 
@@ -11,9 +12,7 @@ const router = useRouter();
 const budget = useBudgetStore();
 const categories = useCategoryStore();
 
-const isEdit = computed(
-  () => typeof route.params.id === 'string' && route.params.id.length > 0,
-);
+const isEdit = computed(() => typeof route.params.id === 'string' && route.params.id.length > 0);
 
 const date = ref('');
 const type = ref('expense');
@@ -27,7 +26,7 @@ const recurringDay = ref(null);
 const saving = ref(false);
 
 const categoryList = computed(() =>
-  type.value === 'income' ? categories.income : categories.expense,
+  type.value === 'income' ? categories.income : categories.expense
 );
 
 function applyTypeFromQuery() {
@@ -79,21 +78,21 @@ watch(
   () => route.params.id,
   () => {
     if (isEdit.value) loadFromRow();
-  },
+  }
 );
 
 watch(
   () => route.query.type,
   () => {
     applyTypeFromQuery();
-  },
+  }
 );
 
 watch(
   () => route.query.date,
   () => {
     applyDateFromQuery();
-  },
+  }
 );
 
 // 수정 시 카테고리 초기화되지 않도록
@@ -120,11 +119,7 @@ function buildPayload() {
     memo: memo.value || '',
     isFixed: isFixed.value,
   };
-  if (
-    isFixed.value &&
-    recurringDay.value != null &&
-    !Number.isNaN(recurringDay.value)
-  ) {
+  if (isFixed.value && recurringDay.value != null && !Number.isNaN(recurringDay.value)) {
     base.recurringDay = recurringDay.value;
   }
   return base;
@@ -164,21 +159,15 @@ function onCancel() {
 
 <template>
   <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold text-foreground">
-        {{ isEdit ? '거래 수정' : '거래 등록' }}
-      </h1>
-      <p class="text-muted-foreground">
-        날짜·금액·카테고리·제목을 입력하고 저장하세요.
-      </p>
-    </div>
+    <PageIntroHeader
+      :title="isEdit ? '거래 수정 ✏️' : '거래 등록 🧾'"
+      description="날짜·금액·카테고리·제목을 입력하고 저장하세요."
+    />
 
     <UiCard class="max-w-lg border-none bg-card/80 shadow-sm backdrop-blur-sm">
       <form class="flex flex-col gap-4 p-6" @submit.prevent="onSubmit">
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="d"
-            >날짜</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="d">날짜</label>
           <input
             id="d"
             v-model="date"
@@ -188,9 +177,7 @@ function onCancel() {
           />
         </div>
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="t"
-            >구분</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="t">구분</label>
           <select
             id="t"
             v-model="type"
@@ -201,9 +188,7 @@ function onCancel() {
           </select>
         </div>
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="c"
-            >카테고리</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="c">카테고리</label>
           <select
             id="c"
             v-model="categoryId"
@@ -217,9 +202,7 @@ function onCancel() {
           </select>
         </div>
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="ti"
-            >제목</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="ti">제목</label>
           <input
             id="ti"
             v-model="title"
@@ -230,9 +213,7 @@ function onCancel() {
           />
         </div>
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="pm"
-            >결제 수단</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="pm">결제 수단</label>
           <select
             id="pm"
             v-model="paymentMethod"
@@ -245,9 +226,7 @@ function onCancel() {
           </select>
         </div>
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="a"
-            >금액</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="a">금액</label>
           <input
             id="a"
             v-model.number="amount"
@@ -259,9 +238,7 @@ function onCancel() {
           />
         </div>
         <div class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="m"
-            >메모</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="m">메모</label>
           <textarea
             id="m"
             v-model="memo"
@@ -271,18 +248,11 @@ function onCancel() {
           />
         </div>
         <div class="flex items-center gap-2">
-          <input
-            id="fx"
-            v-model="isFixed"
-            type="checkbox"
-            class="rounded border-input"
-          />
+          <input id="fx" v-model="isFixed" type="checkbox" class="rounded border-input" />
           <label class="text-sm text-foreground" for="fx">고정 수입·지출</label>
         </div>
         <div v-if="isFixed" class="flex flex-col gap-1">
-          <label class="text-xs font-semibold text-foreground" for="rd"
-            >반복일 (매월)</label
-          >
+          <label class="text-xs font-semibold text-foreground" for="rd">반복일 (매월)</label>
           <input
             id="rd"
             v-model.number="recurringDay"
@@ -294,9 +264,7 @@ function onCancel() {
           />
         </div>
         <div class="flex justify-end gap-2 pt-2">
-          <UiButton type="button" variant="outline" @click="onCancel"
-            >취소</UiButton
-          >
+          <UiButton type="button" variant="outline" @click="onCancel">취소</UiButton>
           <UiButton type="submit" :disabled="saving">
             {{ saving ? '저장 중…' : '저장' }}
           </UiButton>

--- a/bank/sakura_bank_ver_vue/src/features/transactions/views/TransactionListView.vue
+++ b/bank/sakura_bank_ver_vue/src/features/transactions/views/TransactionListView.vue
@@ -4,6 +4,7 @@ import { RouterLink, useRouter } from 'vue-router';
 import { ChevronLeft, ChevronRight } from 'lucide-vue-next';
 import UiCard from '@/shared/ui/UiCard.vue';
 import UiButton from '@/shared/ui/UiButton.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { useBudgetStore } from '@/features/transactions/stores/budget';
 import { useCategoryStore } from '@/features/transactions/stores/categories';
 import { cn } from '@/shared/lib/utils';
@@ -100,10 +101,10 @@ const categoryOptions = computed(() => {
 
 <template>
   <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold text-foreground">거래 내역 💸</h1>
-      <p class="text-muted-foreground">소중한 기록들을 한눈에 확인하고 관리해 보세요</p>
-    </div>
+    <PageIntroHeader
+      title="거래 내역 💸"
+      description="필터와 정렬로 거래를 빠르게 찾고, 필요한 내역을 바로 수정·삭제할 수 있어요."
+    />
 
     <UiCard class="border-none bg-card/80 shadow-sm backdrop-blur-sm">
       <div class="flex flex-wrap items-end gap-3 p-4">

--- a/bank/sakura_bank_ver_vue/src/map/views/MapView.vue
+++ b/bank/sakura_bank_ver_vue/src/map/views/MapView.vue
@@ -7,6 +7,7 @@ import MapSavedPlacesCard from '@/map/components/MapSavedPlacesCard.vue';
 import MapSearchBar from '@/map/components/MapSearchBar.vue';
 import MapSearchResultsCard from '@/map/components/MapSearchResultsCard.vue';
 import MapSummaryCards from '@/map/components/MapSummaryCards.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { useMapLocation } from '@/map/composables/useMapLocation';
 import { useMapPlaces } from '@/map/composables/useMapPlaces';
 import { useMapSearch } from '@/map/composables/useMapSearch';
@@ -19,9 +20,7 @@ const auth = useAuthStore();
 const mapError = ref('');
 const loadingMap = ref(true);
 const mapRef = ref(null);
-const hasMapKey = computed(() =>
-  Boolean(import.meta.env.VITE_NAVER_MAP_CLIENT_ID),
-);
+const hasMapKey = computed(() => Boolean(import.meta.env.VITE_NAVER_MAP_CLIENT_ID));
 
 // 지도 SDK에서 올라오는 이벤트를 Vue 상태 변경 함수와 연결한다.
 const mapScene = createMapScene({
@@ -95,15 +94,10 @@ onMounted(async () => {
 
 <template>
   <div class="space-y-6">
-    <!-- 이 화면이 어떤 기능을 제공하는지 먼저 설명하는 헤더 영역 -->
-    <div>
-      <div>
-        <h1 class="text-2xl font-bold text-foreground">나의 소비지도 🗺️</h1>
-        <p class="text-muted-foreground">
-          자주 방문하는 장소와 지역별 지출 분포를 한눈에 확인해보세요 📍
-        </p>
-      </div>
-    </div>
+    <PageIntroHeader
+      title="나의 소비지도 🗺️"
+      description="자주 방문하는 장소와 지역별 지출 분포를 한눈에 확인해보세요."
+    />
 
     <MapSearchBar
       v-model:keyword="mapSearch.keyword.value"

--- a/bank/sakura_bank_ver_vue/src/views/CalendarView.vue
+++ b/bank/sakura_bank_ver_vue/src/views/CalendarView.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue';
-import { ChevronLeft, ChevronRight, Plus, X } from 'lucide-vue-next';
+import { ChevronLeft, ChevronRight, Plus, X, Pencil, Trash2 } from 'lucide-vue-next';
 import { useRouter } from 'vue-router';
 import UiCard from '@/shared/ui/UiCard.vue';
 import UiButton from '@/shared/ui/UiButton.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { useBudgetStore } from '@/features/transactions/stores/budget';
 import { useCategoryStore } from '@/features/transactions/stores/categories';
+import { useLoadingStore } from '@/stores/loading';
 import { cn } from '@/shared/lib/utils';
 
 const DAYS = ['일', '월', '화', '수', '목', '금', '토'];
@@ -26,6 +28,7 @@ const MONTHS = [
 const budget = useBudgetStore();
 const categoryStore = useCategoryStore();
 const router = useRouter();
+const loadingStore = useLoadingStore();
 onMounted(async () => {
   await Promise.all([budget.fetchAll(), categoryStore.fetchAll()]);
 });
@@ -83,6 +86,34 @@ function onAddTransaction() {
   router.push({ name: 'transaction-new', query: { date: selectedDate.value } });
 }
 
+async function onEditTransaction(id) {
+  loadingStore.showOverlay({
+    context: 'calendar-edit',
+    title: '거래 수정 화면으로 이동 중이에요',
+    description: '선택한 거래를 불러오는 중입니다.',
+  });
+  try {
+    await router.push({ name: 'transaction-edit', params: { id: String(id) } });
+  } finally {
+    loadingStore.hideOverlay();
+  }
+}
+
+async function onDeleteTransaction(id) {
+  if (!window.confirm('이 거래를 삭제할까요?')) return;
+
+  loadingStore.showOverlay({
+    context: 'calendar-delete',
+    title: '거래를 삭제하고 있어요',
+    description: '일별 내역과 통계를 함께 갱신하는 중입니다.',
+  });
+  try {
+    await budget.removeRow(String(id));
+  } finally {
+    loadingStore.hideOverlay();
+  }
+}
+
 const selectedExpenses = computed(() =>
   selectedDate.value ? expensesByDay.value[selectedDate.value] || [] : []
 );
@@ -96,6 +127,12 @@ const selectedNetAmount = computed(() =>
 
 function formatAmount(value) {
   return new Intl.NumberFormat('ko-KR').format(Number(value || 0)) + '원';
+}
+
+function formatMetaText(expense) {
+  const payment = expense.paymentMethod || '결제수단 미기입';
+  const memo = expense.memo || '메모 없음';
+  return `${payment} · ${memo}`;
 }
 
 function selectedDateLabel(dateIso) {
@@ -127,8 +164,12 @@ const calendarCells = computed(() => {
 
 <template>
   <div class="space-y-4">
-    <div class="relative z-[60] flex flex-wrap items-center justify-between gap-2">
-      <h1 class="text-2xl font-bold text-foreground">캘린더 가계부 📅</h1>
+    <div class="relative z-[60] flex flex-wrap items-start justify-between gap-3">
+      <PageIntroHeader
+        title="캘린더 가계부 📅"
+        description="날짜를 눌러 일별 거래를 확인하고, 바로 수정/삭제까지 이어서 관리해보세요."
+        class="min-w-[260px] flex-1"
+      />
       <UiButton
         class="relative z-[60] shrink-0 rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
         @click="onAddTransaction"
@@ -249,13 +290,28 @@ const calendarCells = computed(() => {
                         {{ expense.title }}
                       </p>
                       <p class="text-xs text-muted-foreground">
-                        {{ expense.paymentMethod }} · {{ expense.memo }}
+                        {{ formatMetaText(expense) }}
                       </p>
                     </div>
                     <p :class="expense.type === 'income' ? 'text-blue-600' : 'text-pink-600'">
                       {{ expense.type === 'income' ? '+' : '-'
                       }}{{ expense.amount.toLocaleString() }}원
                     </p>
+                  </div>
+                  <div class="mt-3 flex justify-end gap-2">
+                    <UiButton variant="outline" size="sm" @click="onEditTransaction(expense.id)">
+                      <Pencil class="mr-1 h-3.5 w-3.5" />
+                      수정
+                    </UiButton>
+                    <UiButton
+                      variant="ghost"
+                      size="sm"
+                      class="text-destructive hover:text-destructive"
+                      @click="onDeleteTransaction(expense.id)"
+                    >
+                      <Trash2 class="mr-1 h-3.5 w-3.5" />
+                      삭제
+                    </UiButton>
                   </div>
                 </div>
                 <div class="mt-4 rounded-xl bg-primary/10 p-3 text-center">
@@ -313,12 +369,27 @@ const calendarCells = computed(() => {
                 <div class="flex-1">
                   <p class="font-medium text-foreground">{{ expense.title }}</p>
                   <p class="text-xs text-muted-foreground">
-                    {{ expense.paymentMethod }} · {{ expense.memo }}
+                    {{ formatMetaText(expense) }}
                   </p>
                 </div>
                 <p :class="expense.type === 'income' ? 'text-blue-600' : 'text-pink-600'">
                   {{ expense.type === 'income' ? '+' : '-' }}{{ expense.amount.toLocaleString() }}원
                 </p>
+              </div>
+              <div class="mt-3 flex justify-end gap-2">
+                <UiButton variant="outline" size="sm" @click="onEditTransaction(expense.id)">
+                  <Pencil class="mr-1 h-3.5 w-3.5" />
+                  수정
+                </UiButton>
+                <UiButton
+                  variant="ghost"
+                  size="sm"
+                  class="text-destructive hover:text-destructive"
+                  @click="onDeleteTransaction(expense.id)"
+                >
+                  <Trash2 class="mr-1 h-3.5 w-3.5" />
+                  삭제
+                </UiButton>
               </div>
             </div>
             <div class="mt-4 rounded-xl bg-primary/10 p-3 text-center">

--- a/bank/sakura_bank_ver_vue/src/views/NewsletterView.vue
+++ b/bank/sakura_bank_ver_vue/src/views/NewsletterView.vue
@@ -3,6 +3,7 @@ import { Sparkles, Wallet, Landmark, TrendingUp, ExternalLink } from 'lucide-vue
 import { computed, onMounted, ref, watch } from 'vue';
 import UiCard from '@/shared/ui/UiCard.vue';
 import UiButton from '@/shared/ui/UiButton.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { cn } from '@/shared/lib/utils';
 import { useBudgetStore } from '@/features/transactions/stores/budget';
 import { useCategoryStore } from '@/features/transactions/stores/categories';
@@ -294,12 +295,10 @@ onMounted(async () => {
 
 <template>
   <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold text-foreground">AI 맞춤 소식지 📰</h1>
-      <p class="text-muted-foreground">
-        당신의 소비 패턴과 실시간 검색 정보를 결합한 맞춤형 카드뉴스를 확인하세요
-      </p>
-    </div>
+    <PageIntroHeader
+      title="AI 맞춤 소식지 📰"
+      description="당신의 소비 패턴과 실시간 검색 정보를 결합한 맞춤형 카드뉴스를 확인하세요."
+    />
 
     <UiCard
       class="border-none bg-gradient-to-r from-primary/10 via-amber-50 to-primary/5 shadow-sm backdrop-blur-sm"

--- a/bank/sakura_bank_ver_vue/src/views/ReceiptView.vue
+++ b/bank/sakura_bank_ver_vue/src/views/ReceiptView.vue
@@ -1,11 +1,9 @@
 <template>
   <div class="space-y-6">
-    <!-- 상단 페이지 제목 -->
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-foreground flex items-center gap-2">
-        영수증 스캔 등록 🧾
-      </h1>
-    </div>
+    <PageIntroHeader
+      title="영수증 스캔 등록 🧾"
+      description="사진에서 결제 정보를 추출해 거래 내역으로 빠르게 등록해보세요."
+    />
 
     <!--
     레이아웃 컨테이너
@@ -121,6 +119,7 @@ import { ScanLine, Loader2Icon, CheckCircle2Icon } from 'lucide-vue-next';
 import ReceiptUploader from '@/components/receipt/ReceiptUploader.vue';
 import ReceiptAlertModal from '@/components/receipt/ReceiptAlertModal.vue';
 import InputFormView from '@/components/receipt/InputFormView.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { getRecommendedCategory } from '@/ocr/api/llm';
 import UiCard from '@/shared/ui/UiCard.vue';
 import { cn } from '@/shared/lib/utils';

--- a/bank/sakura_bank_ver_vue/src/views/SettingsView.vue
+++ b/bank/sakura_bank_ver_vue/src/views/SettingsView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import UiCard from '@/shared/ui/UiCard.vue';
 import UiButton from '@/shared/ui/UiButton.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { useProfileStore } from '@/stores/profile';
 import pkg from '../../package.json';
 
@@ -23,10 +24,7 @@ function applyTheme(mode) {
   const root = document.documentElement;
   root.classList.remove('dark');
   if (mode === 'dark') root.classList.add('dark');
-  else if (
-    mode === 'system' &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-  ) {
+  else if (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
     root.classList.add('dark');
   }
 }
@@ -70,7 +68,7 @@ watch(
     monthlyBudget.value = Number(p?.monthlyBudget ?? 0);
     currency.value = p?.currency ?? 'KRW';
   },
-  { immediate: true },
+  { immediate: true }
 );
 
 async function onSave() {
@@ -105,12 +103,10 @@ function clearNewsletterCache() {
 
 <template>
   <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold text-foreground">설정 · 프로필 ⚙️</h1>
-      <p class="text-muted-foreground">
-        이름·연락처·예산과, 이 기기에서만 쓰는 화면·캐시 설정을 바꿀 수 있어요.
-      </p>
-    </div>
+    <PageIntroHeader
+      title="설정 · 프로필 ⚙️"
+      description="이름·연락처·예산과, 이 기기에서만 쓰는 화면·캐시 설정을 바꿀 수 있어요."
+    />
 
     <UiCard class="max-w-lg border-none bg-card/80 shadow-sm backdrop-blur-sm">
       <form class="flex flex-col gap-4 p-6" @submit.prevent="onSave">
@@ -144,9 +140,7 @@ function clearNewsletterCache() {
             step="10000"
             class="rounded-lg border border-input bg-background px-3 py-2"
           />
-          <span class="text-xs text-muted-foreground"
-            >대시보드·목표 진행에 반영됩니다.</span
-          >
+          <span class="text-xs text-muted-foreground">대시보드·목표 진행에 반영됩니다.</span>
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold" for="c">통화</label>
@@ -159,11 +153,7 @@ function clearNewsletterCache() {
             <option value="USD">달러 (USD)</option>
           </select>
         </div>
-        <UiButton
-          type="submit"
-          class="w-fit"
-          :disabled="saving || profile.loading"
-        >
+        <UiButton type="submit" class="w-fit" :disabled="saving || profile.loading">
           {{ saving ? '저장 중…' : '저장' }}
         </UiButton>
       </form>
@@ -171,9 +161,7 @@ function clearNewsletterCache() {
 
     <UiCard class="max-w-lg border-none bg-card/80 shadow-sm backdrop-blur-sm">
       <div class="border-b border-border/50 px-6 py-3">
-        <p class="text-xs font-semibold text-foreground">
-          화면 (이 브라우저만)
-        </p>
+        <p class="text-xs font-semibold text-foreground">화면 (이 브라우저만)</p>
       </div>
       <div class="flex flex-wrap gap-2 p-6 pt-4">
         <UiButton
@@ -209,15 +197,9 @@ function clearNewsletterCache() {
       </div>
       <div class="space-y-3 p-6 pt-4">
         <p class="text-sm text-muted-foreground">
-          생성해 둔 소식지 카드는 새로고침 후에도 보이도록 이 기기에만
-          저장됩니다.
+          생성해 둔 소식지 카드는 새로고침 후에도 보이도록 이 기기에만 저장됩니다.
         </p>
-        <UiButton
-          type="button"
-          variant="outline"
-          class="w-fit"
-          @click="clearNewsletterCache"
-        >
+        <UiButton type="button" variant="outline" class="w-fit" @click="clearNewsletterCache">
           저장된 소식지 지우기
         </UiButton>
       </div>

--- a/bank/sakura_bank_ver_vue/src/views/StatisticsView.vue
+++ b/bank/sakura_bank_ver_vue/src/views/StatisticsView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue';
 import { BarChart3, PieChart as PieIcon } from 'lucide-vue-next';
 import UiCard from '@/shared/ui/UiCard.vue';
+import PageIntroHeader from '@/components/PageIntroHeader.vue';
 import { cn } from '@/shared/lib/utils';
 import { useAuthStore } from '@/stores/auth';
 import { http } from '@/api/http';
@@ -51,9 +52,9 @@ const fetchData = async () => {
       http.get('/categories'),
     ]);
 
-    const records = (
-      Array.isArray(recordRes.data) ? recordRes.data : []
-    ).filter((record) => record.userId === auth.currentUserId);
+    const records = (Array.isArray(recordRes.data) ? recordRes.data : []).filter(
+      (record) => record.userId === auth.currentUserId
+    );
     rawCategories.value = categoryRes.data;
 
     // 최근 6개월 추이 데이터 가공
@@ -129,7 +130,7 @@ const fetchData = async () => {
     // 현재 월 지출 데이터 필터링
     const currentMonth = String(new Date().getMonth() + 1).padStart(2, '0');
     const currentExpenses = records.filter(
-      (r) => r.type === 'expense' && r.date.split('-')[1] === currentMonth,
+      (r) => r.type === 'expense' && r.date.split('-')[1] === currentMonth
     );
 
     // 카테고리 id -> 객체 매핑
@@ -251,25 +252,20 @@ onMounted(fetchData);
 
 <template>
   <div class="space-y-6">
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-foreground">소비 통계 리포트 📈</h1>
-    </div>
+    <PageIntroHeader
+      title="소비 통계 리포트 📈"
+      description="월별 수입·지출 추이와 카테고리별 지출 분포를 한눈에 확인해보세요."
+    />
 
     <div class="flex flex-col gap-6">
       <UiCard class="border-none bg-card/80 shadow-sm backdrop-blur-sm">
         <div class="flex items-center gap-2 p-6 pb-2">
           <BarChart3 class="h-5 w-5 text-primary" />
-          <h2 class="text-lg font-semibold text-foreground">
-            월별 수입/지출 추이
-          </h2>
+          <h2 class="text-lg font-semibold text-foreground">월별 수입/지출 추이</h2>
         </div>
         <div class="p-6">
           <div class="h-[300px] w-full">
-            <BarChart
-              v-if="barData"
-              :chart-data="barData"
-              :chart-options="barOptions"
-            />
+            <BarChart v-if="barData" :chart-data="barData" :chart-options="barOptions" />
           </div>
         </div>
       </UiCard>
@@ -283,18 +279,13 @@ onMounted(fetchData);
         </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-8 p-6">
           <div class="h-[300px] relative flex items-center justify-center">
-            <PieChart
-              v-if="pieData"
-              :chart-data="pieData"
-              :chart-options="pieOptions"
-            />
+            <PieChart v-if="pieData" :chart-data="pieData" :chart-options="pieOptions" />
 
             <div
               v-if="pieData"
               class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none"
             >
-              <span
-                class="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+              <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider"
                 >Total</span
               >
               <span class="text-xl font-bold text-foreground mt-1">
@@ -309,15 +300,10 @@ onMounted(fetchData);
               class="flex items-center justify-between border-b border-border/50 pb-2 last:border-0"
             >
               <div class="flex items-center gap-3">
-                <span
-                  class="h-3 w-3 rounded-full"
-                  :style="{ backgroundColor: item.color }"
-                ></span>
+                <span class="h-3 w-3 rounded-full" :style="{ backgroundColor: item.color }"></span>
                 <span class="font-medium text-foreground">{{ item.name }}</span>
               </div>
-              <span class="font-bold text-foreground"
-                >{{ item.amount.toLocaleString() }}원</span
-              >
+              <span class="font-bold text-foreground">{{ item.amount.toLocaleString() }}원</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#이슈번호

📄  **작업한 내용**
<!-- 작업에 대한 간략한 설명 -->

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 💻 관련 이슈
- Resolved: #이슈번호

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 새로운 페이지 헤더 컴포넌트로 앱 전체의 일관된 헤더 스타일 적용 (오늘의 날짜 및 설명 텍스트 표시)
  * 달력 보기에서 각 거래 기록에 편집 및 삭제 버튼 추가

* **개선 사항**
  * 여러 페이지의 헤더 UI 통합으로 사용자 경험 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->